### PR TITLE
fix for issue #45

### DIFF
--- a/projects/angular2-smart-table/src/lib/angular2-smart-table.component.ts
+++ b/projects/angular2-smart-table/src/lib/angular2-smart-table.component.ts
@@ -279,7 +279,6 @@ export class Angular2SmartTableComponent {
   }
 
   private emitUserSelectRow(row: Row | null) {
-    if (!row) return;
     const selectedRows = this.grid.getSelectedRows();
 
     this.userRowSelect.emit({
@@ -291,7 +290,6 @@ export class Angular2SmartTableComponent {
   }
 
   private emitSelectRow(row: Row | null) {
-    if (!row) return;
     const data = {
       data: row ? row.getData() : null,
       isSelected: row ? row.getIsSelected() : null,

--- a/projects/angular2-smart-table/src/lib/lib/data-set/data-set.ts
+++ b/projects/angular2-smart-table/src/lib/lib/data-set/data-set.ts
@@ -5,7 +5,7 @@ export class DataSet {
 
   newRow!: Row;
 
-  protected data: Array<any> = [];
+  protected data: Array<Row> = [];
   protected columns: Array<Column> = [];
   protected rows: Array<Row> = [];
   protected selectedRow?: Row;
@@ -19,8 +19,13 @@ export class DataSet {
     this.createNewRow();
   }
 
-  setData(data: Array<any>) {
-    this.data = data;
+  setData(data: Array<any>, selectedRows: Array<Row> = []) {
+    const rows: Array<Row> = [...selectedRows];
+    data.map((el: any, index: number) => {
+      const row = new Row( selectedRows.length + index, el, this);
+      rows.push(row);
+    });
+    this.data = rows;
     this.createRows();
   }
 
@@ -148,7 +153,7 @@ export class DataSet {
       this.selectRow(this.rows[index]);
     } else
       // we need to deselect all rows if we got an incorrect index
-      this.deselectAll();
+    else this.deselectAll();
   }
 
   willSelectFirstRow() {
@@ -203,7 +208,7 @@ export class DataSet {
   createRows() {
     this.rows = [];
     this.data.forEach((el, index) => {
-      this.rows.push(new Row(index, el, this));
+      this.rows.push(el);
     });
   }
 }

--- a/projects/angular2-smart-table/src/lib/lib/grid.ts
+++ b/projects/angular2-smart-table/src/lib/lib/grid.ts
@@ -197,7 +197,7 @@ export class Grid {
 
   processDataChange(changes: any) {
     if (this.shouldProcessChange(changes)) {
-      this.dataSet.setData(changes['elements']);
+       this.dataSet.setData(changes['elements'], this.getSelectedRows());
       if (this.getSetting('selectMode') !== 'multi') {
         try {
           const row = this.determineRowToSelect(changes);


### PR DESCRIPTION
this pr will stick the selected rows at top of the table and hence preserve them on events like 'filter', 'sort', 'page', 'remove', 'refresh', 'load', 'paging'
 #45 