### PR TITLE
Fix inputClass not applying to child <input> element in the table filters

### DIFF
--- a/projects/angular2-smart-table/src/lib/components/filter/default-filter.component.ts
+++ b/projects/angular2-smart-table/src/lib/components/filter/default-filter.component.ts
@@ -8,21 +8,21 @@ import {FilterDefault} from "./filter-default";
     <ng-container [ngSwitch]="column.filter.type">
       <select-filter *ngSwitchCase="'list'"
                      [query]="query"
-                     [ngClass]="inputClass"
+                     [inputClass]="inputClass"
                      [debounceTime]="debounceTime"
                      [column]="column"
                      (filter)="onFilter($event)">
       </select-filter>
       <checkbox-filter *ngSwitchCase="'checkbox'"
                        [query]="query"
-                       [ngClass]="inputClass"
+                       [inputClass]="inputClass"
                        [debounceTime]="debounceTime"
                        [column]="column"
                        (filter)="onFilter($event)">
       </checkbox-filter>
       <input-filter *ngSwitchDefault
                     [query]="query"
-                    [ngClass]="inputClass"
+                    [inputClass]="inputClass"
                     [debounceTime]="debounceTime"
                     [column]="column"
                     (filter)="onFilter($event)">


### PR DESCRIPTION
Thanks for maintaining this package! 🙏

### Problem  
In release version **3.5.0**, the `form-control` class was removed from the `<input>`, `<select>`, and checkbox filter elements — which is fine.  
However, the `inputClass` setting is currently being applied to the `input-filter` component itself, instead of the actual child `<input>` element.  
As a result, it's no longer possible to apply classes like `form-control` directly to the input field.

### Solution  
This PR updates the behavior so that the `inputClass` is applied directly to the input element.  

After this change, you can configure it like this:

```json
{
...
  "filter": {
    "inputClass": "form-control"
  }
}
