### PR TITLE
fix: remove duplicate search label in multiselect filter dropdown

### DIFF
--- a/projects/angular2-smart-table/src/lib/components/filter/filter-types/multiselect-filter.component.html
+++ b/projects/angular2-smart-table/src/lib/components/filter/filter-types/multiselect-filter.component.html
@@ -10,16 +10,15 @@
 
     @if (dropdownOpen) {
       <div class="multi-select-dropdown" (scroll)="$event.stopPropagation()" (wheel)="onDropdownWheel($event)">
-        <div class="dropdown-header">
-          <label for="search-input">{{searchTitle}}</label>
-          <input type="text"
-                id="search-input"
-                class="search-input"
-                [placeholder]="searchPlaceholder"
-                [value]="searchText"
-                (input)="onSearchChange($event)"
-                (click)="$event.stopPropagation()"
-                aria-label="Search">
+       <div class="dropdown-header">
+        <input type="text"
+              id="search-input"
+              class="search-input"
+              [placeholder]="searchPlaceholder"
+              [value]="searchText"
+              (input)="onSearchChange($event)"
+              (click)="$event.stopPropagation()"
+              aria-label="Search">
           <div class="action-buttons">
             <button type="button" (click)="selectAll($event)">{{ selectAllButtonText }}</button>
             <button type="button" (click)="clearAll($event)">{{ clearAllButtonText }}</button>

--- a/projects/angular2-smart-table/src/lib/components/filter/filter-types/multiselect-filter.component.ts
+++ b/projects/angular2-smart-table/src/lib/components/filter/filter-types/multiselect-filter.component.ts
@@ -26,7 +26,6 @@ export class MultiSelectFilterComponent extends DefaultFilter implements OnInit,
   clearButtonText = 'Clear Filter';
   selectAllButtonText = 'Select All';
   clearAllButtonText = 'Clear All';
-  searchTitle = 'Search';
   searchPlaceholder = 'Search...';
   selectText = 'Select...'; // Default text when nothing selected
   maxDisplayedSelections = 2; // Default max items to show before count format
@@ -48,7 +47,6 @@ export class MultiSelectFilterComponent extends DefaultFilter implements OnInit,
     this.clearButtonText = this.config.clearButtonText ?? this.clearAllButtonText;
     this.selectAllButtonText = this.config.selectAllButtonText ?? this.selectAllButtonText;
     this.clearAllButtonText = this.config.clearAllButtonText ?? this.clearAllButtonText;
-    this.searchTitle = this.config.searchTitle ?? this.searchTitle;
     this.searchPlaceholder = this.config.searchPlaceholder ?? this.searchPlaceholder;
 
     // Set selection display text

--- a/projects/angular2-smart-table/src/lib/lib/settings.ts
+++ b/projects/angular2-smart-table/src/lib/lib/settings.ts
@@ -112,8 +112,7 @@ export interface MultiSelectFilterSettings {
   clearButtonText?: string;      // Default: 'Clear Filter'
   selectAllButtonText?: string;  // Default: 'Select All'
   clearAllButtonText?: string;   // Default: 'Clear All'
-  searchTitle?: string;          // Default: 'Search'
-  searchPlaceholder?: string;    // Default: 'Search...'
+   searchPlaceholder?: string;    // Default: 'Search...'
 
   // Optional - display configuration
   maxDisplayedSelections?: number;  // Default: 2 - Max items shown before count format


### PR DESCRIPTION
Remove redundant <label> element that was displaying "Search" above the search input field, causing duplication with the input's placeholder text "Search...".

Changes:
- Removed <label for="search-input">{{searchTitle}}</label> from template
- Removed unused searchTitle property from component class
- Removed searchTitle initialization from config in ngOnInit()

The input field's placeholder and aria-label already provide sufficient indication of the field's purpose. This creates a cleaner, less cluttered UI in the filter dropdown.

Screenshot before fix showed "Search" label text above "Search..." placeholder, causing visual duplication.

<img width="303" height="592" alt="image" src="https://github.com/user-attachments/assets/58326678-369f-4cae-8e40-a8480fec3f43" />
