### PR TITLE
fix multiselect filter dropdown overflowing the viewport height

### DIFF
--- a/projects/angular2-smart-table/CHANGELOG.md
+++ b/projects/angular2-smart-table/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 This document lists the changes introduced by this fork.
 
+## Unreleased
+
+* Fix that the multiselect filter dropdown overflows the viewport height when there is not enough space
+  below the filter (for example when the browser is zoomed in), which cut off the options and put the
+  apply/clear buttons out of reach. The dropdown now flips above the filter when that leaves more room,
+  is limited to the space that is actually available, and is kept inside the viewport in any case.
+* The multiselect filter dropdown now grows to fit its options instead of always being limited to
+  400 pixels, as long as the viewport has room for it
+
 ## Version 4.1.1
 
 * Fix that the demo page was broken by the Angular 21 upgrade

--- a/projects/angular2-smart-table/src/lib/components/filter/filter-types/multiselect-filter.component.scss
+++ b/projects/angular2-smart-table/src/lib/components/filter/filter-types/multiselect-filter.component.scss
@@ -38,7 +38,9 @@
     border: 1px solid #ccc;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
     z-index: 1000;
+    // Fallback only - the component replaces this with the height that actually fits the viewport.
     max-height: 400px;
+    overflow: hidden;
     flex-direction: column;
     background: white;
   }
@@ -78,7 +80,9 @@
   .options-list {
     overflow-y: auto;
     flex: 1 1 auto;
-    min-height: 100px;
+    // Must be able to shrink below its content height, otherwise it pushes the footer
+    // out of the dropdown when the available viewport space is small.
+    min-height: 0;
     padding: 0.25em 0;
   }
 

--- a/projects/angular2-smart-table/src/lib/components/filter/filter-types/multiselect-filter.component.ts
+++ b/projects/angular2-smart-table/src/lib/components/filter/filter-types/multiselect-filter.component.ts
@@ -159,11 +159,37 @@ export class MultiSelectFilterComponent extends DefaultFilter implements OnInit,
     const dropdown = this.multiSelectDropdown?.nativeElement;
     if (trigger == undefined || dropdown == undefined) return;
 
-    const rect = trigger.getBoundingClientRect();
-    const minWidth = Math.max(280, rect.width);
+    const margin = 2;
+    const minHeight = 120;
+    const viewportHeight = document.documentElement.clientHeight;
 
-    dropdown.style.top = `${rect.bottom + 2}px`;
-    dropdown.style.minWidth = `${minWidth}px`;
+    // Measure the unconstrained height first. 'none' is required to also defeat the stylesheet's
+    // fallback max-height - clearing the inline value alone would cap the measurement at that value.
+    // This must be reset on every run, otherwise each call would measure the height left over by
+    // the previous one (this runs on scroll/resize too).
+    dropdown.style.maxHeight = 'none';
+
+    const rect = trigger.getBoundingClientRect();
+    dropdown.style.minWidth = `${Math.max(280, rect.width)}px`;
+
+    const naturalHeight = dropdown.offsetHeight;
+    const spaceBelow = viewportHeight - rect.bottom - margin;
+    const spaceAbove = rect.top - margin;
+
+    // Open downwards by default, and flip above the trigger only when that leaves more room.
+    const openAbove = naturalHeight > spaceBelow && spaceAbove > spaceBelow;
+    const available = openAbove ? spaceAbove : spaceBelow;
+
+    // Grow to fit the options when there is room, and only scroll once the viewport runs out.
+    // The last clamp matters when neither side can satisfy minHeight, e.g. under heavy zoom.
+    const height = Math.min(naturalHeight, Math.max(available, minHeight), viewportHeight - 2 * margin);
+
+    dropdown.style.maxHeight = `${height}px`;
+
+    // Keep the dropdown fully inside the viewport even when neither side has enough room
+    // (e.g. under heavy browser zoom); overlapping the trigger is preferable to being cut off.
+    const top = openAbove ? rect.top - height - margin : rect.bottom + margin;
+    dropdown.style.top = `${Math.max(margin, Math.min(top, viewportHeight - height - margin))}px`;
 
     let left = rect.left;
     // shift the horizontal position to the left when there is not enough space on the right


### PR DESCRIPTION
## Summary

The multiselect filter dropdown could be cut off by the bottom of the viewport, putting
options and the apply/clear buttons out of reach. This is the vertical counterpart to the
horizontal overflow fix released in 4.0.1 ("Fix that the new multiselect filter dropdown
overflows the viewport width when opened for a column that is close to the right edge of
the viewport").

## Problem

`updateDropdownPosition()` always placed the dropdown directly below the trigger:

```ts
dropdown.style.top = `${rect.bottom + 2}px`;
```

combined with a fixed `max-height: 400px` in the stylesheet. It corrected for horizontal
overflow only - it never checked whether 400px actually fit below the trigger.

When the space below is smaller than the dropdown, the lower part is simply cut off. Since
the dropdown is `position: fixed`, scrolling the page does not reveal it either, so the
hidden options and buttons are genuinely unreachable.

### Steps to reproduce

1. Open the demo and zoom the browser in (or use a short window).
2. Open a multiselect column filter whose header sits in the lower half of the viewport.
3. The bottom of the option list and the apply/clear buttons are clipped off-screen.

## Solution

The dropdown now measures its unconstrained height, opens above the trigger when that side
has more room, limits itself to the space actually available, and is clamped into the
viewport as a final guarantee:

```ts
const openAbove = naturalHeight > spaceBelow && spaceAbove > spaceBelow;
const available = openAbove ? spaceAbove : spaceBelow;
const height = Math.min(naturalHeight, Math.max(available, minHeight), viewportHeight - 2 * margin);

const top = openAbove ? rect.top - height - margin : rect.bottom + margin;
dropdown.style.top = `${Math.max(margin, Math.min(top, viewportHeight - height - margin))}px`;
```

Two supporting changes were required to make this effective:

- **Reset `max-height` to `'none'` before measuring.** Clearing only the inline value leaves
  the stylesheet fallback in place, which caps the measurement at that value. This also
  matters because the method runs on scroll and resize, so without a reset each call would
  measure the height left over by the previous call rather than the natural height.
- **`min-height: 0` on `.options-list`** (was `100px`) so it can shrink below its content
  height. Otherwise it pushes the footer out of the dropdown when space is tight, which is
  what made the apply/clear buttons disappear.

`overflow: hidden` was added to `.multi-select-dropdown` as a guard against content spilling
outside the box, and the stylesheet `max-height: 400px` is kept and commented as a pre-JS
fallback.

## Behaviour change (please review)

The dropdown is **no longer effectively capped at 400px** - it grows to fit its options as
long as the viewport has room. Consumers with long option lists will see taller dropdowns
than before.

This was deliberate (a fixed cap forces scrolling even when the screen has plenty of space),
but it is arguably an enhancement bundled with a bugfix. If you would prefer to keep the
previous cap, the natural alternative is a `maxHeight` option on `MultiSelectFilterSettings`
defaulting to `400`, clamped to `min(config, available)`. Happy to change it to that, or to
split it into a separate commit/PR.

## Testing

Verified manually in the browser across zoom levels, with the filter near the top, middle and
bottom of the viewport, and while scrolling and resizing with the dropdown open:

- Enough room below - opens downward, sized to its content, no scrollbar.
- Not enough room below but more above - flips above the trigger.
- Neither side sufficient - clamped to the viewport, options list scrolls, apply/clear stay
  visible.

No unit tests were added: the repository has no specs for the filter components, and this
behaviour depends on real layout geometry (`getBoundingClientRect`, `offsetHeight`), which
would need browser-based tests to cover meaningfully. Happy to add some if you have a
preferred approach.

## Changes

- `multiselect-filter.component.ts` - viewport-aware sizing and positioning
- `multiselect-filter.component.scss` - `min-height: 0`, `overflow: hidden`, comment on the fallback cap
- `CHANGELOG.md` - entry under `Unreleased`

No API changes, no new dependencies, template untouched.